### PR TITLE
fix: [emerg] could not build map_hash

### DIFF
--- a/x-ui-pro.sh
+++ b/x-ui-pro.sh
@@ -235,6 +235,7 @@ ln -s /etc/letsencrypt/live/${domain}/privkey.pem /root/cert/${domain}/privkey.p
 
 mkdir -p /etc/nginx/stream-enabled
 cat > "/etc/nginx/stream-enabled/stream.conf" << EOF
+map_hash_bucket_size 128;
 map \$ssl_preread_server_name \$sni_name {
     hostnames;
     ${reality_domain}      xray;


### PR DESCRIPTION
С длинными доменами можно словить ошибку
```
nginx -t
nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32
nginx: configuration file /etc/nginx/nginx.conf test failed
```

Из-за этого установка прервётся с ошибкой `nginx config is not ok!`